### PR TITLE
Update Selenium's deprecated driver_path arg to new Service object format

### DIFF
--- a/lib/kimurai/browser_builder/selenium_chrome_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_chrome_builder.rb
@@ -110,7 +110,8 @@ module Kimurai::BrowserBuilder
         end
 
         chromedriver_path = Kimurai.configuration.chromedriver_path || "/usr/local/bin/chromedriver"
-        Capybara::Selenium::Driver.new(app, browser: :chrome, options: driver_options, driver_path: chromedriver_path)
+        service = Selenium::WebDriver::Service.chrome(path: chromedriver_path)
+        Capybara::Selenium::Driver.new(app, browser: :chrome, options: driver_options, service: service)
       end
 
       # Create browser instance (Capybara session)


### PR DESCRIPTION
Selenium's `:driver_path` param has been deprecated in favor of `:service`.

This approach avoids receiving the following warning:

```
WARN Selenium [DEPRECATION] :driver_path is deprecated. Use :service with an instance of Selenium::WebDriver::Service instead.
```