### PR TITLE
feat: allow preset cookies url

### DIFF
--- a/lib/kimurai/base.rb
+++ b/lib/kimurai/base.rb
@@ -198,7 +198,7 @@ module Kimurai
         logger.warn "Spider: request_to: not unique url: #{url}, skipped" and return
       end
 
-      visited = delay ? browser.visit(url, delay: delay) : browser.visit(url)
+      visited = delay ? browser.visit(url, delay: delay, preset_cookies_url: data[:preset_cookies_url]) : browser.visit(url, preset_cookies_url: data[:preset_cookies_url])
       return unless visited
 
       public_send(handler, browser.current_response(response_type), { url: url, data: data })


### PR DESCRIPTION
From https://www.selenium.dev/documentation/support_packages/working_with_cookies/

> Add Cookie
> 
> It is used to add a cookie to the current browsing context. Add Cookie only accepts a set of defined serializable JSON object. Here is the link to the list of accepted JSON key values
> 
> First of all, you need to be on the domain that the cookie will be valid for. If you are trying to preset cookies before you start interacting with a site and your homepage is large / takes a while to load an alternative is to find a smaller page on the site (typically the 404 page is small, e.g. http://example.com/some404page)

Selenium recommends to load a small page to load the cookies before interacting with a site.

This PR allows to set a custom url to set cookies.

```ruby
@start_urls = [{ url: "http://example.com", data: { preset_cookies_url: "http://example.com/some404page" } }]
```

(Kind of) fixes https://github.com/vifreefly/kimuraframework/issues/63