### PR TITLE
Ruby 3 Compatibility + Crawl Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # CHANGELOG
+## 1.6.0
+* Rename `additional_arguments` config option to `browser_cmd_line_arguments` (see [All available config options](https://github.com/vifreefly/kimuraframework#all-available-config-options))
+
+## 1.5.0
+### New
+* Add `additional_arguments` config option (see [All available config options](https://github.com/vifreefly/kimuraframework#all-available-config-options))
+
+## 1.4.1
+New
+* Updated for Ruby 2.7+ support
+* Switched to Addressable.URI.escape from obsolete URI.escape
+
 ## 1.4.0
 ### New
 * Add `encoding` config option (see [All available config options](https://github.com/vifreefly/kimuraframework#all-available-config-options))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ class GithubSpider < Kimurai::Base
   }
 
   def parse(response, url:, data: {})
-    response.xpath("//ul[@class='repo-list']/div//h3/a").each do |a|
+    response.xpath("//ul[@class='repo-list']//a[@class='v-align-middle']").each do |a|
       request_to :parse_repo_page, url: absolute_url(a[:href], base: url)
     end
 
@@ -36,7 +36,7 @@ class GithubSpider < Kimurai::Base
     item[:repo_name] = response.xpath("//h1/strong[@itemprop='name']/a").text
     item[:repo_url] = url
     item[:description] = response.xpath("//span[@itemprop='about']").text.squish
-    item[:tags] = response.xpath("//div[@id='topics-list-container']/div/a").map { |a| a.text.squish }
+    item[:tags] = response.xpath("//div[starts-with(@class, 'list-topics-container')]/a").map { |a| a.text.squish }
     item[:watch_count] = response.xpath("//ul[@class='pagehead-actions']/li[contains(., 'Watch')]/a[2]").text.squish
     item[:star_count] = response.xpath("//ul[@class='pagehead-actions']/li[contains(., 'Star')]/a[2]").text.squish
     item[:fork_count] = response.xpath("//ul[@class='pagehead-actions']/li[contains(., 'Fork')]/a[2]").text.squish
@@ -208,51 +208,51 @@ I, [2018-08-22 13:33:30 +0400#23356] [M: 47375890851320]  INFO -- infinite_scrol
 * Command-line [runner](#runner) to run all project spiders one by one or in parallel
 
 ## Table of Contents
-* [Kimurai](#kimurai)
-  * [Features](#features)
-  * [Table of Contents](#table-of-contents)
-  * [Installation](#installation)
-  * [Getting to Know](#getting-to-know)
-    * [Interactive console](#interactive-console)
-    * [Available engines](#available-engines)
-    * [Minimum required spider structure](#minimum-required-spider-structure)
-    * [Method arguments response, url and data](#method-arguments-response-url-and-data)
-    * [browser object](#browser-object)
-    * [request_to method](#request_to-method)
-    * [save_to helper](#save_to-helper)
-    * [Skip duplicates](#skip-duplicates)
-      * [Automatically skip all duplicated requests urls](#automatically-skip-all-duplicated-requests-urls)
-      * [Storage object](#storage-object)
-    * [Handle request errors](#handle-request-errors)
-      * [skip_request_errors](#skip_request_errors)
-      * [retry_request_errors](#retry_request_errors)
-    * [Logging custom events](#logging-custom-events)
-    * [open_spider and close_spider callbacks](#open_spider-and-close_spider-callbacks)
-    * [KIMURAI_ENV](#kimurai_env)
-    * [Parallel crawling using in_parallel](#parallel-crawling-using-in_parallel)
-    * [Active Support included](#active-support-included)
-    * [Schedule spiders using Cron](#schedule-spiders-using-cron)
-    * [Configuration options](#configuration-options)
-    * [Using Kimurai inside existing Ruby application](#using-kimurai-inside-existing-ruby-application)
-      * [crawl! method](#crawl-method)
-      * [parse! method](#parsemethod_name-url-method)
-      * [Kimurai.list and Kimurai.find_by_name](#kimurailist-and-kimuraifind_by_name)
-    * [Automated sever setup and deployment](#automated-sever-setup-and-deployment)
-      * [Setup](#setup)
-      * [Deploy](#deploy)
-  * [Spider @config](#spider-config)
-    * [All available @config options](#all-available-config-options)
-    * [@config settings inheritance](#config-settings-inheritance)
-  * [Project mode](#project-mode)
-    * [Generate new spider](#generate-new-spider)
-    * [Crawl](#crawl)
-    * [List](#list)
-    * [Parse](#parse)
-    * [Pipelines, send_item method](#pipelines-send_item-method)
-    * [Runner](#runner)
-      * [Runner callbacks](#runner-callbacks)
-  * [Chat Support and Feedback](#chat-support-and-feedback)
-  * [License](#license)
+- [Kimurai](#kimurai)
+  - [Features](#features)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Getting to Know](#getting-to-know)
+    - [Interactive console](#interactive-console)
+    - [Available engines](#available-engines)
+    - [Minimum required spider structure](#minimum-required-spider-structure)
+    - [Method arguments `response`, `url` and `data`](#method-arguments-response-url-and-data)
+    - [`browser` object](#browser-object)
+    - [`request_to` method](#request_to-method)
+    - [`save_to` helper](#save_to-helper)
+    - [Skip duplicates](#skip-duplicates)
+      - [Automatically skip all duplicated requests urls](#automatically-skip-all-duplicated-requests-urls)
+      - [`storage` object](#storage-object)
+    - [Handle request errors](#handle-request-errors)
+      - [skip_request_errors](#skip_request_errors)
+      - [retry_request_errors](#retry_request_errors)
+    - [Logging custom events](#logging-custom-events)
+    - [`open_spider` and `close_spider` callbacks](#open_spider-and-close_spider-callbacks)
+    - [`KIMURAI_ENV`](#kimurai_env)
+    - [Parallel crawling using `in_parallel`](#parallel-crawling-using-in_parallel)
+    - [Active Support included](#active-support-included)
+    - [Schedule spiders using Cron](#schedule-spiders-using-cron)
+    - [Configuration options](#configuration-options)
+    - [Using Kimurai inside existing Ruby application](#using-kimurai-inside-existing-ruby-application)
+      - [`.crawl!` method](#crawl-method)
+      - [`.parse!(:method_name, url:, config: {})` method](#parsemethod_name-url-config--method)
+      - [`Kimurai.list` and `Kimurai.find_by_name()`](#kimurailist-and-kimuraifind_by_name)
+    - [Automated sever setup and deployment](#automated-sever-setup-and-deployment)
+      - [Setup](#setup)
+      - [Deploy](#deploy)
+  - [Spider `@config`](#spider-config)
+    - [All available `@config` options](#all-available-config-options)
+    - [`@config` settings inheritance](#config-settings-inheritance)
+  - [Project mode](#project-mode)
+    - [Generate new spider](#generate-new-spider)
+    - [Crawl](#crawl)
+    - [List](#list)
+    - [Parse](#parse)
+    - [Pipelines, `send_item` method](#pipelines-send_item-method)
+    - [Runner](#runner)
+      - [Runner callbacks](#runner-callbacks)
+  - [Chat Support and Feedback](#chat-support-and-feedback)
+  - [License](#license)
 
 
 ## Installation
@@ -654,7 +654,7 @@ def request_to(handler, url:, data: {})
   request_data = { url: url, data: data }
 
   browser.visit(url)
-  public_send(handler, browser.current_response, request_data)
+  public_send(handler, browser.current_response, **request_data)
 end
 ```
 </details><br>
@@ -1302,6 +1302,9 @@ Kimurai.configure do |config|
   # config.selenium_chrome_path = "/usr/bin/chromium-browser"
   # Provide custom selenium chromedriver path (default is "/usr/local/bin/chromedriver"):
   # config.chromedriver_path = "~/.local/bin/chromedriver"
+
+  # Provide additional command line arguments that will passed to the browser
+  # config.browser_cmd_line_arguments = %w[--disable-gpu]
 end
 ```
 
@@ -1344,7 +1347,7 @@ end # =>
 
 So what if you're don't care about stats and just want to process request to a particular spider method and get the returning value from this method? Use `.parse!` instead:
 
-#### `.parse!(:method_name, url:)` method
+#### `.parse!(:method_name, url:, config: {})` method
 
 `.parse!` (class method) creates a new spider instance and performs a request to given method with a given url. Value from the method will be returned back:
 
@@ -1361,6 +1364,8 @@ end
 
 ExampleSpider.parse!(:parse, url: "https://example.com/")
 # => "Example Domain"
+# this is example when you need to override config
+ExampleSpider.parse!(:parse, url: "https://example.com/", config: { before_request: { clear_and_set_cookies: true } } )
 ```
 
 Like `.crawl!`, `.parse!` method takes care of a browser instance and kills it (`browser.destroy_driver!`) before returning the value. Unlike `.crawl!`, `.parse!` method can be called from different threads at the same time:

--- a/kimurai.gemspec
+++ b/kimurai.gemspec
@@ -37,12 +37,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "headless"
   spec.add_dependency "pmap"
 
+  spec.add_dependency "addressable"
   spec.add_dependency "whenever"
 
   spec.add_dependency "rbcat", "~> 0.2"
   spec.add_dependency "pry"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/kimurai/base_helper.rb
+++ b/lib/kimurai/base_helper.rb
@@ -1,16 +1,18 @@
+require 'addressable/uri'
+
 module Kimurai
   module BaseHelper
     private
 
     def absolute_url(url, base:)
       return unless url
-      URI.join(base, URI.escape(url)).to_s
+      URI.join(base, Addressable::URI.escape(url)).to_s
     end
 
     def escape_url(url)
       uri = URI.parse(url)
     rescue URI::InvalidURIError => e
-      URI.parse(URI.escape url).to_s rescue url
+      URI.parse(Addressable::URI.escape(url)).to_s rescue url
     else
       url
     end

--- a/lib/kimurai/browser_builder/poltergeist_phantomjs_builder.rb
+++ b/lib/kimurai/browser_builder/poltergeist_phantomjs_builder.rb
@@ -50,6 +50,12 @@ module Kimurai::BrowserBuilder
           logger.debug "BrowserBuilder (poltergeist_phantomjs): enabled disable_images"
         end
 
+        # Additional arguments
+        if @config[:browser_cmd_line_arguments].present?
+          driver_options[:phantomjs_options] += @config[:browser_cmd_line_arguments]
+          logger.debug "BrowserBuilder (poltergeist_phantomjs): additional browser command line arguments have been added"
+        end
+
         Capybara::Poltergeist::Driver.new(app, driver_options)
       end
 

--- a/lib/kimurai/browser_builder/selenium_chrome_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_chrome_builder.rb
@@ -28,9 +28,12 @@ module Kimurai::BrowserBuilder
         if chrome_path = Kimurai.configuration.selenium_chrome_path
           opts.merge!(binary: chrome_path)
         end
-
         # See all options here: https://seleniumhq.github.io/selenium/docs/api/rb/Selenium/WebDriver/Chrome/Options.html
-        driver_options = Selenium::WebDriver::Chrome::Options.new(opts)
+        driver_options = Selenium::WebDriver::Chrome::Options.new(**opts)
+
+        if @config[:debugger_address]
+          driver_options.add_option(:debuggerAddress, @config[:debugger_address])
+        end
 
         # Window size
         if size = @config[:window_size].presence
@@ -107,6 +110,12 @@ module Kimurai::BrowserBuilder
             driver_options.args << "--headless"
             logger.debug "BrowserBuilder (selenium_chrome): enabled native headless_mode"
           end
+        end
+
+        # Additional arguments
+        if @config[:browser_cmd_line_arguments].present?
+          driver_options.args << @config[:browser_cmd_line_arguments].join(' ')
+          logger.debug "BrowserBuilder (selenium_chrome): additional browser command line arguments have been added"
         end
 
         chromedriver_path = Kimurai.configuration.chromedriver_path || "/usr/local/bin/chromedriver"

--- a/lib/kimurai/browser_builder/selenium_firefox_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_firefox_builder.rb
@@ -110,6 +110,12 @@ module Kimurai::BrowserBuilder
           end
         end
 
+        # Additional arguments
+        if @config[:browser_cmd_line_arguments].present?
+          driver_options.args <<  @config[:browser_cmd_line_arguments].join(' ')
+          logger.debug "BrowserBuilder (selenium_firefox): additional browser command line arguments have been added"
+        end
+
         Capybara::Selenium::Driver.new(app, browser: :firefox, options: driver_options)
       end
 

--- a/lib/kimurai/capybara_ext/mechanize/driver.rb
+++ b/lib/kimurai/capybara_ext/mechanize/driver.rb
@@ -34,7 +34,7 @@ class Capybara::Mechanize::Driver
     options[:name]  ||= name
     options[:value] ||= value
 
-    cookie = Mechanize::Cookie.new(options.merge path: "/")
+    cookie = Mechanize::Cookie.new(**options.merge(path: "/"))
     browser.agent.cookie_jar << cookie
   end
 

--- a/lib/kimurai/version.rb
+++ b/lib/kimurai/version.rb
@@ -1,3 +1,3 @@
 module Kimurai
-  VERSION = "1.4.0"
+  VERSION = "1.9.0"
 end


### PR DESCRIPTION
Allow passing `data: {}` into crawl! from this branch `https://github.com/dtengeri/kimuraframework`

Ruby 3 compatibility from this branch: `https://github.com/n-studio/kimuraframework`

Hopefully this PR gets merged into the main branch so everyone can benefit but if not I hope this branch helps a future traveler by providing a branch that merges two useful disparate branches.
