### PR TITLE
Fix ssl_cert_path configuration for mechanize engine

### DIFF
--- a/lib/kimurai/browser_builder/mechanize_builder.rb
+++ b/lib/kimurai/browser_builder/mechanize_builder.rb
@@ -47,7 +47,7 @@ module Kimurai::BrowserBuilder
 
       # SSL
       if ssl_cert_path = @config[:ssl_cert_path].presence
-        @browser.driver.browser.agent.http.ca_file = ssl_cert_path
+        @browser.driver.browser.agent.ca_file = ssl_cert_path
         logger.debug "BrowserBuilder (mechanize): enabled custom ssl_cert"
       end
 


### PR DESCRIPTION
`ca_path=` method is on the main Mechanize class as documented here:
https://www.rubydoc.info/gems/mechanize/Mechanize#ca_file=-instance_method

Fixes #35 for mechanize engine
