### PR TITLE
Fix csv warning on gemspec

### DIFF
--- a/kimurai.gemspec
+++ b/kimurai.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "murmurhash3"
   spec.add_dependency "nokogiri"
+  spec.add_dependency "csv"
 
   spec.add_dependency "capybara", ">= 2.15", "< 4.0"
   spec.add_dependency "capybara-mechanize"


### PR DESCRIPTION
This fixes "warning: ~/.rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of kimurai-1.4.0 to add csv into its gemspec."